### PR TITLE
Make default disk size 50GB

### DIFF
--- a/00-install-packages.sh
+++ b/00-install-packages.sh
@@ -17,11 +17,33 @@
 set -xe
 
 sudo apt-get update
+sudo apt-get remove --purge -y vagrant
 sudo apt-get install --no-install-recommends -y \
         ca-certificates \
         git \
         make \
         nmap \
         curl \
-        vagrant \
-        virtualbox
+        dnsmasq-base \
+        ebtables \
+        libvirt-bin \
+        libvirt-dev \
+        libxml2-dev \
+        libxslt-dev \
+        qemu \
+        ruby-dev \
+        virtualbox \
+        zlib1g-dev
+
+# NOTE(drewwalters96): Install latest vagrant version for compatibility with
+# vagrant-disksize plugin.
+INSTALL_LOCATION="$(mktemp -d)"
+INSTALL_FILE="${INSTALL_LOCATION}/vagrant.zip"
+
+curl -L -o "$INSTALL_FILE" \
+  https://releases.hashicorp.com/vagrant/2.2.5/vagrant_2.2.5_linux_amd64.zip
+
+unzip "$INSTALL_FILE"
+sudo mv "$INSTALL_LOCATION/vagrant" /usr/bin/vagrant
+
+rm -rf "$INSTALL_LOCATION"

--- a/etc/Vagrantfile
+++ b/etc/Vagrantfile
@@ -3,6 +3,7 @@ Vagrant.configure("2") do |config|
     n1.vm.box = "ubuntu/xenial64"
     n1.vm.hostname = "n1"
     n1.vm.network "private_network", ip: "172.24.1.10"
+    n1.disksize.size = "50GB"
 
     n1.vm.provider "virtualbox" do |vb|
       vb.name = "n1"
@@ -18,6 +19,7 @@ Vagrant.configure("2") do |config|
     n2.vm.box = "ubuntu/xenial64"
     n2.vm.hostname = "n2"
     n2.vm.network "private_network", ip: "172.24.1.11"
+    n2.disksize.size = "50GB"
 
     n2.vm.provider "virtualbox" do |vb|
       vb.name = "n2"
@@ -33,6 +35,7 @@ Vagrant.configure("2") do |config|
     n3.vm.box = "ubuntu/xenial64"
     n3.vm.hostname = "n3"
     n3.vm.network "private_network", ip: "172.24.1.12"
+    n3.disksize.size = "50GB"
 
     n3.vm.provider "virtualbox" do |vb|
       vb.name = "n3"


### PR DESCRIPTION
The default disk size of each VM is currently 10GB. Installing
additional services causes the cluster to break. This commit moves the
default disk size to 50GB so additional services can be installed.